### PR TITLE
Fixed type conversion error

### DIFF
--- a/APsystemsEZ1/__init__.py
+++ b/APsystemsEZ1/__init__.py
@@ -260,7 +260,7 @@ class APsystemsEZ1M:
         request = await self._request(f"setMaxPower?p={power_limit}")
         return int(request["data"]["maxPower"]) if request else None
 
-    async def get_device_power_status(self) -> bool | None:
+    async def get_device_power_status(self) -> bool:
         """
         Retrieves the current power status of the device. This method sends a request to the
         "getOnOff" endpoint and returns a dictionary containing the power status of the device.
@@ -272,7 +272,14 @@ class APsystemsEZ1M:
         :return: 0/normal when on, 1/alarm when off
         """
         response = await self._request("getOnOff")
-        return not bool(int(response["data"]["status"])) if response else None
+
+        match (status := response["data"]["status"]):
+            case int():
+                return not bool(status)
+            case str() if status.isdigit():
+                return not bool(int(status))
+            case _:
+                raise InverterReturnedError
 
     async def set_device_power_status(
         self, power_status: bool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apsystems-ez1"
-version = "2.2.1"
+version = "2.3.1"
 description = "The APsystems EZ1 Python library offers a streamlined interface for interacting with the local API of APsystems EZ1 Microinverters."
 authors = ["Sonnenladen GmbH <l.tiedt@sonnenladen.de>"]
 readme = "README.md"

--- a/tests/unit_tests/test_get_device_power_status.py
+++ b/tests/unit_tests/test_get_device_power_status.py
@@ -1,5 +1,7 @@
 import pytest
 
+from APsystemsEZ1 import InverterReturnedError
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -21,7 +23,6 @@ async def test_get_device_power_status_happy_paths(
     # Assert
     assert status == expected_status, f"Test failed for {test_id}"
 
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "test_id, output_data",
@@ -34,9 +35,8 @@ async def test_get_device_power_status_value_error(test_id, output_data, mock_re
     ez1m = mock_response(output_data)
 
     # Assert
-    with pytest.raises(ValueError):
+    with pytest.raises(InverterReturnedError):
         await ez1m.get_device_power_status()
-
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(


### PR DESCRIPTION
This commit fixes an error that occurred when the response status returned an empty string instead of an int or something that could be cast into an int.

My proposed solution is a bit more verbose compared to the original version (but I think still 'Pythonic'). I've removed the test for a `ValueError` because there should never be an error here. Furthermore, the `ValueError` was not handled in the HA integration, so it might be better not to raise it implicitly.

Please be aware that this might also require some changes in the HA integration, because in [PR 123225](https://github.com/home-assistant/core/pull/123225) it is assumed that the value of `status` is always a `boolean`.

Thanks for your work and for providing a FOSS API for your product. I look forward to your feedback.

Note: I am not the owner of an APSystems device; I just want to support you :)