### PR TITLE
fix: get/set power on recent firmwares

### DIFF
--- a/APsystemsEZ1/__init__.py
+++ b/APsystemsEZ1/__init__.py
@@ -295,13 +295,16 @@ class APsystemsEZ1M:
     async def get_max_power(self) -> int | None:
         """Retrieves the set maximum power setting of the device. This method makes a request to the
         "getMaxPower" endpoint and returns a dictionary containing the maximum power limit of the device set by the user.
+        Note that in some firmware versions, the "maxPower" response key has been renamed to "power".
 
         :return: Max output power in watts
         """
         response = await self._request("getMaxPower")
-        if response is None or response["data"]["maxPower"] == "":
-            return None
-        return int(response["data"]["maxPower"])
+        if response and int(response["data"].get("maxPower", 0)) > 0:
+            return int(response["data"].get("maxPower", 0))
+        if response and int(response["data"].get("power", 0)) > 0:
+            return int(response["data"].get("power", 0))
+        return None
 
     async def set_max_power(self, power_limit: int) -> int | None:
         """
@@ -319,13 +322,18 @@ class APsystemsEZ1M:
 
         The key in the 'data' object is:
         - 'maxPower': Indicates the newly set maximum power output of the device in watts.
+        Note that in some firmware versions, the "maxPower" response key has been renamed to "power".
         """
         if not self.min_power <= power_limit <= self.max_power:
             raise ValueError(
                 f"Invalid setMaxPower value: expected int between '30' and '800', got '{power_limit}'"
             )
         request = await self._request(f"setMaxPower?p={power_limit}")
-        return int(request["data"]["maxPower"]) if request else None
+        if request and int(request["data"].get("maxPower", 0)) > 0:
+            return int(request["data"]["maxPower"])
+        if request and int(request["data"].get("power", 0)) > 0:
+            return int(request["data"]["power"])
+        return None
 
     async def get_device_power_status(self) -> bool:
         """


### PR DESCRIPTION
On some (recent?) firmwares, the "maxPower" response key has been renamed to "power" within the firmware.
Possibly to prevent confusion between the "max power set by the user" and the "max power supported by the device", both being named "maxPower" in older versions.

For more information, see https://github.com/home-assistant/core/issues/136288#issuecomment-2764499413

The linked issue also states that the "status" (get_device_power_status) is missing on some firmwares. This is also the case on mine, and the corresponding HTTP endpoint has simply disappeared from the firmware API, so unsure there's a replacement.

This PR is live on my Home Assistant system, and it correctly restores the max output modifiable sensor.